### PR TITLE
chore: Add pipelines to manually deploy to environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment-environment:
+        required: true
+        type: choice
+        options:
+          - dev
+          - stg
+          - prd
+        default: prd
+        description: Environment
+      tag:
+        required: true
+        default: 'latest'
+        type: string
+        description: 'Docker tag (quay.io)'
+
+jobs:
+  deployment:
+    if: ${{ inputs.deployment-environment }}
+    name: 'Deploy to: ${{ inputs.deployment-environment }}'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deployment-environment }}
+    steps:
+      - name: Trigger deployment
+        id: deploy
+        uses: decentraland/dcl-deploy-action@main
+        with:
+          dockerImage: 'quay.io/decentraland/linker-server:${{ inputs.tag }}'
+          serviceName: 'linker-server'
+          env: ${{ inputs.deployment-environment }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,3 @@
-
-
 name: CI/CD on main branch
 
 on:
@@ -12,7 +10,7 @@ jobs:
     uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
     with:
       service-name: linker-server
-      deployment-environment: prd stg
+      deployment-environment: dev stg
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Build and publish
+on:
+  release:
+    types:
+      - created
+jobs:
+  build:
+    name: 'Build & publish: ${{github.ref_name}}'
+    uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
+    with:
+      service-name: linker-server
+      docker-tag: '${{ github.ref_name }}'
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
This PR updates the default pipeline to deploy to `dev` and `stg`.

It also adds two new pipelines for manually deploying to a specific environment and generates docker images based on releases.