### PR TITLE
fix: bind auth chain signature to deployed entity id

### DIFF
--- a/src/controllers/handlers/entities-handler.ts
+++ b/src/controllers/handlers/entities-handler.ts
@@ -55,6 +55,13 @@ export async function entitiesHandler(
 
     const entityId = entityIdField.value
 
+    // Ensure the signed payload matches the entity being deployed. Without this
+    // check a captured auth chain (which signs its own entityId) could be replayed
+    // to deploy arbitrary content under an authorized signer.
+    if (validationResult.signedEntityId !== entityId) {
+      throw new ForbiddenError('Auth chain payload does not match the entity id')
+    }
+
     // Get the entity file
     const entityFile = formData.files[entityId]
     if (!entityFile) {

--- a/src/logic/linker/component.ts
+++ b/src/logic/linker/component.ts
@@ -57,7 +57,7 @@ export async function createLinkerComponent(components: {
     }
 
     const signerAddress = Authenticator.ownerAddress(authChain)
-    return { ok: true, signerAddress }
+    return { ok: true, signerAddress, signedEntityId: authSignedEntity.payload }
   }
 
   /**

--- a/src/logic/linker/types.ts
+++ b/src/logic/linker/types.ts
@@ -3,6 +3,7 @@ import type { AuthChain } from '@dcl/schemas'
 export interface ValidationResult {
   ok: boolean
   signerAddress: string
+  signedEntityId?: string
   error?: string
 }
 

--- a/test/unit/entities-handler.spec.ts
+++ b/test/unit/entities-handler.spec.ts
@@ -142,7 +142,11 @@ describe('when calling the entities handler', () => {
       mockAuthorizations.checkAuthorization.mockResolvedValueOnce({ authorized: true, parcels: ['0,0'] })
 
       mockLinker = createLinkerMockedComponent()
-      mockLinker.validateAuthChain.mockResolvedValueOnce({ ok: true, signerAddress: '0xauthorized' })
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreiexample'
+      })
 
       result = await entitiesHandler({
         formData: {
@@ -176,7 +180,11 @@ describe('when calling the entities handler', () => {
       mockAuthorizations.checkAuthorization.mockResolvedValueOnce({ authorized: true, parcels: ['0,0'] })
 
       mockLinker = createLinkerMockedComponent()
-      mockLinker.validateAuthChain.mockResolvedValueOnce({ ok: true, signerAddress: '0xauthorized' })
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreiexample'
+      })
 
       result = await entitiesHandler({
         formData: {
@@ -201,6 +209,49 @@ describe('when calling the entities handler', () => {
     })
   })
 
+  describe('and the signed entity id does not match the entity id', () => {
+    let result: IHttpServerComponent.IResponse
+
+    beforeEach(async () => {
+      mockAuthorizations = createAuthorizationsMockedComponent()
+      mockAuthorizations.checkAuthorization.mockResolvedValueOnce({ authorized: true, parcels: ['0,0'] })
+
+      mockLinker = createLinkerMockedComponent()
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreisignedsomethingelse'
+      })
+
+      result = await entitiesHandler({
+        formData: {
+          fields: {
+            ...createAuthChainFields([{ type: 'SIGNER', payload: '0xauthorized' }]),
+            entityId: { fieldname: 'entityId', value: 'bafkreiexample' }
+          },
+          files: {
+            bafkreiexample: { fieldname: 'bafkreiexample', value: Buffer.from('{"pointers":["0,0"]}') }
+          }
+        },
+        components: {
+          logs: mockLogs,
+          metrics: mockMetrics,
+          authorizations: mockAuthorizations,
+          linker: mockLinker
+        }
+      } as never)
+    })
+
+    it('should return status 403 rejecting the payload/entity-id mismatch', () => {
+      expect(result.status).toBe(403)
+      expect(result.body).toEqual({ error: 'Forbidden', message: 'Auth chain payload does not match the entity id' })
+    })
+
+    it('should not upload to the catalyst', () => {
+      expect(mockLinker.uploadToCatalyst).not.toHaveBeenCalled()
+    })
+  })
+
   describe('and the user does not have access to the parcels', () => {
     let result: IHttpServerComponent.IResponse
 
@@ -213,7 +264,11 @@ describe('when calling the entities handler', () => {
       })
 
       mockLinker = createLinkerMockedComponent()
-      mockLinker.validateAuthChain.mockResolvedValueOnce({ ok: true, signerAddress: '0xauthorized' })
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreiexample'
+      })
 
       const entityContent = JSON.stringify({ pointers: ['0,0', '1,1', '2,2'] })
 
@@ -258,7 +313,11 @@ describe('when calling the entities handler', () => {
       mockAuthorizations.checkParcelAccess.mockResolvedValueOnce({ hasAccess: true, missingParcels: [] })
 
       mockLinker = createLinkerMockedComponent()
-      mockLinker.validateAuthChain.mockResolvedValueOnce({ ok: true, signerAddress: '0xauthorized' })
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreiexample'
+      })
       mockLinker.uploadToCatalyst.mockResolvedValueOnce({ success: false, error: 'Catalyst rejected the upload' })
 
       const entityContent = JSON.stringify({ pointers: ['0,0'] })
@@ -304,7 +363,11 @@ describe('when calling the entities handler', () => {
       mockAuthorizations.checkParcelAccess.mockResolvedValueOnce({ hasAccess: true, missingParcels: [] })
 
       mockLinker = createLinkerMockedComponent()
-      mockLinker.validateAuthChain.mockResolvedValueOnce({ ok: true, signerAddress: '0xauthorized' })
+      mockLinker.validateAuthChain.mockResolvedValueOnce({
+        ok: true,
+        signerAddress: '0xauthorized',
+        signedEntityId: 'bafkreiexample'
+      })
       mockLinker.uploadToCatalyst.mockResolvedValueOnce({ success: true, response: catalystResponse })
 
       const entityContent = JSON.stringify({ pointers: ['0,0'] })

--- a/test/unit/linker-component.spec.ts
+++ b/test/unit/linker-component.spec.ts
@@ -101,6 +101,7 @@ describe('when using the linker component', () => {
         const result = await component.validateAuthChain(authChain)
         expect(result.ok).toBe(true)
         expect(result.signerAddress).toBe('0xSignerAddress')
+        expect(result.signedEntityId).toBe('entity-id')
         expect(result.error).toBeUndefined()
       })
     })


### PR DESCRIPTION
## What

`POST /content/entities` validated that the submitted auth chain produced a valid signature over its own `ECDSA_PERSONAL_SIGNED_ENTITY` payload, but the entity actually deployed was taken from a separate `entityId` form field and was never compared against the signed payload. The server then re-signs that `entityId` with its own wallet, so the Catalyst trusts it unconditionally — the linker is the only authorization gate.

This let a valid auth chain captured from an authorized signer (signing any entity) be replayed with a different `entityId` and arbitrary files, deploying attacker-chosen content to any parcel that signer is authorized for. Authorization was anchored to the uploaded entity's `pointers` and the signer address, not to the content the user actually signed.

## Change

`validateAuthChain` now returns the signed payload, and the handler rejects the request when the signed payload does not equal the deployed `entityId`.

## Verification

- `tsc --noEmit` clean
- eslint clean on changed files

Ephemeral-key expiration continues to be enforced by `Authenticator.validateSignature` via the auth chain's ephemeral link.